### PR TITLE
Fix REGEX errors, ParserUtilTest; Change StringUtil method

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -14,11 +14,11 @@ public class StringUtil {
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
+     *   Ignores case.
      *   <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
      *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       containsWordIgnoreCase("ABc def", "AB") == true // substring match will return true
      *       </pre>
      * @param sentence cannot be null
      * @param word cannot be null, cannot be empty, must be a single word
@@ -35,7 +35,7 @@ public class StringUtil {
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
         return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+                .anyMatch(p -> p.toLowerCase().contains(preppedWord.toLowerCase()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/workout/Equipment.java
+++ b/src/main/java/seedu/address/model/workout/Equipment.java
@@ -16,7 +16,7 @@ public class Equipment {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String EQUIPMENT_VALIDATION_REGEX = "[\\p{Alnum}|, ][\\p{Alnum}|, ]*";
+    public static final String EQUIPMENT_VALIDATION_REGEX = "[\\p{Alpha}|,][\\p{Alpha} |, ]*";
 
     public final String fullEquipment;
 

--- a/src/main/java/seedu/address/model/workout/Muscle.java
+++ b/src/main/java/seedu/address/model/workout/Muscle.java
@@ -16,7 +16,7 @@ public class Muscle {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String MUSCLE_VALIDATION_REGEX = "[\\p{Alnum}|, ][\\p{Alnum}|, ]*";
+    public static final String MUSCLE_VALIDATION_REGEX = "[\\p{Alpha}|,][\\p{Alpha} |, ]*";
 
     public final String fullMuscle;
 

--- a/src/main/java/seedu/address/model/workout/Type.java
+++ b/src/main/java/seedu/address/model/workout/Type.java
@@ -16,7 +16,7 @@ public class Type {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String TYPE_VALIDATION_REGEX = "[\\p{Alnum}|, ][\\p{Alnum}|, ]*";
+    public static final String TYPE_VALIDATION_REGEX = "[\\p{Alpha}|,][\\p{Alpha} |, ]*";
 
     public final String fullType;
 

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -123,10 +123,10 @@ public class StringUtilTest {
         assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
 
         // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
         assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
 
         // Matches word in the sentence, different upper/lower case letters
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word contains query word as substring
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bBb ccc", "Bbb")); // First word (boundary case)
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
         assertTrue(StringUtil.containsWordIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -21,14 +21,14 @@ import seedu.address.model.tag.Tag;
 import seedu.address.testutil.Assert;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_TYPE = "+651234";
-    private static final String INVALID_DURATION = "22h";
-    private static final String INVALID_DIFFICULTY = "bob";
-    private static final String INVALID_EQUIPMENT = "easy";
-    private static final String INVALID_MUSCLE = "bench";
-    private static final String INVALID_CALORIES = "132D";
-    private static final String INVALID_INSTRUCTION = "24123";
+    private static final String INVALID_NAME = "James's workout&";
+    private static final String INVALID_TYPE = "strength + cardio";
+    private static final String INVALID_DURATION = "5 minutes";
+    private static final String INVALID_DIFFICULTY = "difficult";
+    private static final String INVALID_EQUIPMENT = "dumbbell + mat";
+    private static final String INVALID_MUSCLE = "bicep + tricep";
+    private static final String INVALID_CALORIES = "123 calories";
+    //no invalid instructions
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "commando workout";
@@ -38,7 +38,7 @@ public class ParserUtilTest {
     private static final String VALID_EQUIPMENT = "bench";
     private static final String VALID_MUSCLE = "biceps";
     private static final String VALID_CALORIES = "150";
-    private static final String VALID_INSTRUCTION = "set 1: bicep curl reps: 4-6 set 2: tricep extension reps: 4-6 ";
+    private static final String VALID_INSTRUCTION = "set 1: bicep curl reps: 4-6 set 2: tricep extension reps: 4-6";
     private static final String VALID_TAG_1 = "crazy";
     private static final String VALID_TAG_2 = "fun";
 
@@ -70,7 +70,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseName_null_throwsNullPointerException() {
+    public void paxrseName_null_throwsNullPointerEception() {
         Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
     }
 
@@ -233,11 +233,6 @@ public class ParserUtilTest {
     @Test
     public void parseInstruction_null_throwsNullPointerException() {
         Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseInstruction((String) null));
-    }
-
-    @Test
-    public void parseInstruction_invalidValue_throwsParseException() {
-        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseInstruction(INVALID_INSTRUCTION));
     }
 
     @Test


### PR DESCRIPTION
Fix:
1. REGEX errors in Type, Equipment and Muscle parameters to only allow alphabets, commas and whitespaces
2. Copy invalid constants as defined in CommandTestUtil.java to ParserUtilTest.java for standardisation of invalid cases

Change:
1. StringUtil method containsWordIgnoreCase() to return true for substring match instead of having to match the full word
2. StringUtilTest to match the new function of containsWordIgnoreCase()