### PR TITLE
Fix XmlSerializableWorkoutBookTest, Find & EditCommandSystemTest

### DIFF
--- a/src/test/data/XmlSerializableWorkoutBookTest/typicalWorkoutsWorkoutBook.xml
+++ b/src/test/data/XmlSerializableWorkoutBookTest/typicalWorkoutsWorkoutBook.xml
@@ -21,7 +21,7 @@
 		<muscle>deltoids</muscle>
 		<calories>100</calories>
 		<instruction>set1: shoulder press reps: 5-7</instruction>
-        <tagged>relax</tagged>
+        <tagged>heavy</tagged>
     </workouts>
     <workouts>
 		<name>Carl Kurz's workout</name>

--- a/src/test/data/XmlSerializableWorkoutBookTest/typicalWorkoutsWorkoutBook.xml
+++ b/src/test/data/XmlSerializableWorkoutBookTest/typicalWorkoutsWorkoutBook.xml
@@ -21,6 +21,7 @@
 		<muscle>deltoids</muscle>
 		<calories>100</calories>
 		<instruction>set1: shoulder press reps: 5-7</instruction>
+        <tagged>relax</tagged>
     </workouts>
     <workouts>
 		<name>Carl Kurz's workout</name>

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -3,37 +3,7 @@ package systemtests;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.DURATION_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.DURATION_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DURATION_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.DIFFICULTY_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.DIFFICULTY_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DIFFICULTY_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.EQUIPMENT_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.EQUIPMENT_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EQUIPMENT_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.MUSCLE_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.MUSCLE_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MUSCLE_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.CALORIES_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.CALORIES_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_CALORIES_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.INSTRUCTION_DESC_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.INSTRUCTION_DESC_BOB_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_INSTRUCTION_AMY_WORKOUT;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_MORNING;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_NIGHT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_MORNING;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_NIGHT;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_WORKOUTS;
@@ -51,15 +21,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
-import seedu.address.model.workout.Name;
-import seedu.address.model.workout.Workout;
-import seedu.address.model.workout.Type;
-import seedu.address.model.workout.Duration;
-import seedu.address.model.workout.Difficulty;
-import seedu.address.model.workout.Equipment;
-import seedu.address.model.workout.Muscle;
-import seedu.address.model.workout.Calories;
-import seedu.address.model.workout.Instruction;
+import seedu.address.model.workout.*;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.WorkoutBuilder;
 import seedu.address.testutil.WorkoutUtil;
@@ -76,11 +38,11 @@ public class EditCommandSystemTest extends WorkoutBookSystemTest {
          * -> edited
          */
         Index index = INDEX_FIRST_WORKOUT;
-        String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + NAME_DESC_BOB_WORKOUT + "  "
-                + TYPE_DESC_BOB_WORKOUT + " " + DURATION_DESC_BOB_WORKOUT + "  " + DIFFICULTY_DESC_BOB_WORKOUT + " "
-                + EQUIPMENT_DESC_BOB_WORKOUT + " " + MUSCLE_DESC_BOB_WORKOUT + " " + CALORIES_DESC_BOB_WORKOUT + " "
-                + INSTRUCTION_DESC_BOB_WORKOUT + " " + TAG_DESC_MORNING + " " + TAG_DESC_NIGHT + " ";
-        Workout editedWorkout = new WorkoutBuilder(BOB_WORKOUT).withTags(VALID_TAG_MORNING).withTags(VALID_TAG_NIGHT).build();
+        String command = "  " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + NAME_DESC_BOB_WORKOUT
+                + "  " + TYPE_DESC_BOB_WORKOUT + "  " + DURATION_DESC_BOB_WORKOUT + "  " + DIFFICULTY_DESC_BOB_WORKOUT
+                + "  " + EQUIPMENT_DESC_BOB_WORKOUT + "  " + MUSCLE_DESC_BOB_WORKOUT + "  " + CALORIES_DESC_BOB_WORKOUT
+                + "  " + INSTRUCTION_DESC_BOB_WORKOUT + "  " + TAG_DESC_NIGHT + " ";
+        Workout editedWorkout = new WorkoutBuilder(BOB_WORKOUT).withTags(VALID_TAG_NIGHT).build();
         assertCommandSuccess(command, index, editedWorkout);
 
         /* Case: undo editing the last workout in the list -> last workout restored */
@@ -97,32 +59,9 @@ public class EditCommandSystemTest extends WorkoutBookSystemTest {
 
         /* Case: edit a workout with new values same as existing values -> edited */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandSuccess(command, index, BOB_WORKOUT);
-
-        /* Case: edit a workout with new values same as another workout's values but with different name -> edited */
-        assertTrue(getModel().getWorkoutBook().getWorkoutList().contains(BOB_WORKOUT));
-        index = INDEX_SECOND_WORKOUT;
-        assertNotEquals(getModel().getFilteredWorkoutList().get(index.getZeroBased()), BOB_WORKOUT);
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
-        editedWorkout = new WorkoutBuilder(BOB_WORKOUT).withName(VALID_NAME_AMY_WORKOUT).build();
-        assertCommandSuccess(command, index, editedWorkout);
-
-        /* Case: edit a workout with new values same as another workout's values but with different type, duration, difficulty,
-        equipment, muscle, calories and instruction
-         * -> edited
-         */
-        index = INDEX_SECOND_WORKOUT;
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_AMY_WORKOUT
-                + DURATION_DESC_AMY_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_AMY_WORKOUT
-                + MUSCLE_DESC_AMY_WORKOUT + CALORIES_DESC_AMY_WORKOUT + INSTRUCTION_DESC_AMY_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
-        editedWorkout = new WorkoutBuilder(BOB_WORKOUT).withType(VALID_TYPE_AMY_WORKOUT).withDuration(VALID_DURATION_AMY_WORKOUT)
-                .withDifficulty(VALID_DIFFICULTY_AMY_WORKOUT).withEquipment(VALID_EQUIPMENT_AMY_WORKOUT).withMuscle(VALID_MUSCLE_AMY_WORKOUT)
-                .withCalories(VALID_CALORIES_AMY_WORKOUT).withInstruction(VALID_INSTRUCTION_AMY_WORKOUT).build();
-        assertCommandSuccess(command, index, editedWorkout);
 
         /* Case: clear tags -> cleared */
         index = INDEX_FIRST_WORKOUT;
@@ -133,14 +72,17 @@ public class EditCommandSystemTest extends WorkoutBookSystemTest {
 
         /* ------------------ Performing edit operation while a filtered list is being shown ------------------------ */
 
-        /* Case: filtered workout list, edit index within bounds of address book and workout list -> edited */
-        showWorkoutsWithName(KEYWORD_MATCHING_MEIER);
-        index = INDEX_FIRST_WORKOUT;
-        assertTrue(index.getZeroBased() < getModel().getFilteredWorkoutList().size());
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + NAME_DESC_BOB_WORKOUT;
-        workoutToEdit = getModel().getFilteredWorkoutList().get(index.getZeroBased());
-        editedWorkout = new WorkoutBuilder(workoutToEdit).withName(VALID_NAME_BOB_WORKOUT).build();
-        assertCommandSuccess(command, index, editedWorkout);
+        /**
+         * this test is causing an "Exception in Async Thread", can't find a way to solve it at the moment
+         */
+//        /* Case: filtered workout list, edit index within bounds of address book and workout list -> edited */
+//        showWorkoutsWithName(KEYWORD_MATCHING_MEIER);
+//        index = INDEX_FIRST_WORKOUT;
+//        assertTrue(index.getZeroBased() < getModel().getFilteredWorkoutList().size());
+//        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + NAME_DESC_BOB_WORKOUT;
+//        workoutToEdit = getModel().getFilteredWorkoutList().get(index.getZeroBased());
+//        editedWorkout = new WorkoutBuilder(workoutToEdit).withName(VALID_NAME_BOB_WORKOUT).build();
+//        assertCommandSuccess(command, index, editedWorkout);
 
         /* Case: filtered workout list, edit index within bounds of address book but out of bounds of workout list
          * -> rejected
@@ -159,8 +101,8 @@ public class EditCommandSystemTest extends WorkoutBookSystemTest {
         index = INDEX_FIRST_WORKOUT;
         selectWorkout(index);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY_WORKOUT + TYPE_DESC_AMY_WORKOUT
-                + DURATION_DESC_AMY_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_AMY_WORKOUT + MUSCLE_DESC_AMY_WORKOUT
-                + CALORIES_DESC_AMY_WORKOUT + INSTRUCTION_DESC_AMY_WORKOUT + TAG_DESC_MORNING;
+                + DURATION_DESC_AMY_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_AMY_WORKOUT
+                + MUSCLE_DESC_AMY_WORKOUT + CALORIES_DESC_AMY_WORKOUT + INSTRUCTION_DESC_AMY_WORKOUT + TAG_DESC_MORNING;
         // this can be misleading: card selection actually remains unchanged but the
         // browser's url is updated to reflect the new workout's name
         assertCommandSuccess(command, index, AMY_WORKOUT, index);
@@ -189,43 +131,36 @@ public class EditCommandSystemTest extends WorkoutBookSystemTest {
                 EditCommand.MESSAGE_NOT_EDITED);
 
         /* Case: invalid name -> rejected */
-        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_NAME_DESC,
-                Name.MESSAGE_NAME_CONSTRAINTS);
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_NAME_DESC, Name.MESSAGE_NAME_CONSTRAINTS);
 
-        /**
-         * To be uncommented once invalid test cases are thought of
-         */
-//        /* Case: invalid type -> rejected */
-//        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_TYPE_DESC,
-//                Type.MESSAGE_TYPE_CONSTRAINTS);
-//
-//        /* Case: invalid duration -> rejected */
-//        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_DURATION_DESC,
-//                Duration.MESSAGE_DURATION_CONSTRAINTS);
-//
-//        /* Case: invalid difficulty -> rejected */
-//        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_DIFFICULTY_DESC,
-//                Difficulty.MESSAGE_DIFFICULTY_CONSTRAINTS);
-//
-//        /* Case: invalid equipment -> rejected */
-//        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_EQUIPMENT_DESC,
-//                Equipment.MESSAGE_EQUIPMENT_CONSTRAINTS);
-//
-//        /* Case: invalid muscle -> rejected */
-//        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_MUSCLE_DESC,
-//                Muscle.MESSAGE_MUSCLE_CONSTRAINTS);
-//
-//        /* Case: invalid calories -> rejected */
-//        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_CALORIES_DESC,
-//                Calories.MESSAGE_CALORIES_CONSTRAINTS);
-//
-//        /* Case: invalid instruction -> rejected */
-//        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_INSTRUCTION_DESC,
-//                Instruction.MESSAGE_INSTRUCTION_CONSTRAINTS);
+        /* Case: invalid type -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_TYPE_DESC, Type.MESSAGE_TYPE_CONSTRAINTS);
+
+        /* Case: invalid duration -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_DURATION_DESC, Duration.MESSAGE_DURATION_CONSTRAINTS);
+
+        /* Case: invalid difficulty -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_DIFFICULTY_DESC, Difficulty.MESSAGE_DIFFICULTY_CONSTRAINTS);
+
+        /* Case: invalid equipment -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_EQUIPMENT_DESC, Equipment.MESSAGE_EQUIPMENT_CONSTRAINTS);
+
+        /* Case: invalid muscle -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_MUSCLE_DESC, Muscle.MESSAGE_MUSCLE_CONSTRAINTS);
+
+        /* Case: invalid calories -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_CALORIES_DESC, Calories.MESSAGE_CALORIES_CONSTRAINTS);
 
         /* Case: invalid tag -> rejected */
-        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased() + INVALID_TAG_DESC,
-                Tag.MESSAGE_TAG_CONSTRAINTS);
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_WORKOUT.getOneBased()
+                        + INVALID_TAG_DESC, Tag.MESSAGE_TAG_CONSTRAINTS);
 
         /* Case: edit a workout with new values same as another workout's values -> rejected */
         executeCommand(WorkoutUtil.getAddCommand(BOB_WORKOUT));
@@ -233,56 +168,72 @@ public class EditCommandSystemTest extends WorkoutBookSystemTest {
         index = INDEX_FIRST_WORKOUT;
         assertFalse(getModel().getFilteredWorkoutList().get(index.getZeroBased()).equals(BOB_WORKOUT));
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT  + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different tags -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different tags
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different type -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different type
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_AMY_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different duration -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different duration
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_AMY_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_AMY_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different difficulty -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different difficulty
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different equipment -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different equipment
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_AMY_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_BOB_WORKOUT + EQUIPMENT_DESC_AMY_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different muscle -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different muscle
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_AMY_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_AMY_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different calories -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different calories
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_AMY_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_AMY_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
 
-        /* Case: edit a workout with new values same as another workout's values but with different instruction -> rejected */
+        /* Case: edit a workout with new values same as another workout's values but with different instruction
+         * -> rejected
+         */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB_WORKOUT + TYPE_DESC_BOB_WORKOUT
-                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT + MUSCLE_DESC_BOB_WORKOUT
-                + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_MORNING + TAG_DESC_NIGHT;
+                + DURATION_DESC_BOB_WORKOUT + DIFFICULTY_DESC_AMY_WORKOUT + EQUIPMENT_DESC_BOB_WORKOUT
+                + MUSCLE_DESC_BOB_WORKOUT + CALORIES_DESC_BOB_WORKOUT + INSTRUCTION_DESC_BOB_WORKOUT + TAG_DESC_NIGHT;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_WORKOUT);
     }
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -75,14 +75,14 @@ public class EditCommandSystemTest extends WorkoutBookSystemTest {
         /**
          * this test is causing an "Exception in Async Thread", can't find a way to solve it at the moment
          */
-//        /* Case: filtered workout list, edit index within bounds of address book and workout list -> edited */
-//        showWorkoutsWithName(KEYWORD_MATCHING_MEIER);
-//        index = INDEX_FIRST_WORKOUT;
-//        assertTrue(index.getZeroBased() < getModel().getFilteredWorkoutList().size());
-//        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + NAME_DESC_BOB_WORKOUT;
-//        workoutToEdit = getModel().getFilteredWorkoutList().get(index.getZeroBased());
-//        editedWorkout = new WorkoutBuilder(workoutToEdit).withName(VALID_NAME_BOB_WORKOUT).build();
-//        assertCommandSuccess(command, index, editedWorkout);
+        /* Case: filtered workout list, edit index within bounds of address book and workout list -> edited */
+        showWorkoutsWithName(KEYWORD_MATCHING_MEIER);
+        index = INDEX_FIRST_WORKOUT;
+        assertTrue(index.getZeroBased() < getModel().getFilteredWorkoutList().size());
+        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + TYPE_DESC_BOB_WORKOUT;
+        workoutToEdit = getModel().getFilteredWorkoutList().get(index.getZeroBased());
+        editedWorkout = new WorkoutBuilder(workoutToEdit).withType(VALID_TYPE_BOB_WORKOUT).build();
+        assertCommandSuccess(command, index, editedWorkout);
 
         /* Case: filtered workout list, edit index within bounds of address book but out of bounds of workout list
          * -> rejected

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -30,7 +30,8 @@ public class FindCommandSystemTest extends WorkoutBookSystemTest {
          */
         String command = "   " + FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER + "   ";
         Model expectedModel = getModel();
-        ModelHelper.setFilteredList(expectedModel, BENSON_WORKOUT, DANIEL_WORKOUT); // first names of Benson and Daniel are "Meier"
+        ModelHelper.setFilteredList(expectedModel, BENSON_WORKOUT, DANIEL_WORKOUT);
+        // last names of Benson and Daniel are "Meier"
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
@@ -94,9 +95,8 @@ public class FindCommandSystemTest extends WorkoutBookSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find workout in workout book, keyword is substring of name -> 0 workouts found */
+        /* Case: find workout in workout book, keyword is substring of name -> 1 workouts found */
         command = FindCommand.COMMAND_WORD + " Mei";
-        ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 


### PR DESCRIPTION
Fix:
1. missing tag in Benson Meier's Workout in typicalWorkoutsWorkoutBook.xml was causing an error in an assertEquals()
2. case where keyword is substring of name, removed filtering that goes against new logic for FindCommand, which is that substring match will return positive result
3. Test case for editing within bounds of a filtered list to match with updated duplicate rules
4. match BOB_WORKOUT edit fields to match BOB_WORKOUT provided by TypicalWorkouts.java
5. remove assertCommandSuccess cases that will result in duplicate workouts as per updated duplicate rules
6. coding standards: 120 characters per line